### PR TITLE
#2 ローカルのファイルを読み出して再生する機能の追加

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,7 +13,8 @@ function createWindow(): void {
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      nodeIntegration: true // FIXME: RendererからもNodeを使えるためXSSの危険性あり
     }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,11 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  // NOTE: dev環境では開発者ツールを開く
+  if (is.dev) {
+    mainWindow.webContents.openDevTools()
+  }
+
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,5 +4,10 @@ declare global {
   interface Window {
     electron: ElectronAPI
     api: unknown
+    fileSystem: FileSystemAPI
+  }
+
+  interface FileSystemAPI {
+    readFile: (filePath: string) => Promise<Buffer>
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import fs from 'fs'
+import { readFile } from 'fs/promises'
 
 // Custom APIs for renderer
 const api = {}
@@ -25,14 +25,6 @@ if (process.contextIsolated) {
 // ファイル読み込みをrendererで使う
 contextBridge.exposeInMainWorld('fileSystem', {
   readFile: (filePath: string) => {
-    return new Promise((resolve, reject) => {
-      fs.readFile(filePath, (err, data) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(data)
-        }
-      })
-    })
+    return readFile(filePath)
   }
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import fs from 'fs'
 
 // Custom APIs for renderer
 const api = {}
@@ -20,3 +21,18 @@ if (process.contextIsolated) {
   // @ts-ignore (define in dts)
   window.api = api
 }
+
+// ファイル読み込みをrendererで使う
+contextBridge.exposeInMainWorld('fileSystem', {
+  readFile: (filePath: string) => {
+    return new Promise((resolve, reject) => {
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+})

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; img-src 'self' data:"
     />
   </head>
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,13 +1,13 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import Home from './components/Home'
-import Sample from './components/Sample'
+import Player from './components/Player'
 
 function App(): JSX.Element {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/sample" element={<Sample />} />
+        <Route path="/player" element={<Player />} />
       </Routes>
     </Router>
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
+import { HashRouter as Router, Route, Routes } from 'react-router-dom'
 import Home from './components/Home'
 import Player from './components/Player'
 

--- a/src/renderer/src/components/Home.tsx
+++ b/src/renderer/src/components/Home.tsx
@@ -6,7 +6,7 @@ function Home(): JSX.Element {
 
   // WARN: 動画再生のテストのための処理であるため後で置き換える
   const [videoFilePath, setVideoFilePath] = useState<string | null>(null)
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const selectedFile = event.target.files?.[0]
     if (selectedFile) setVideoFilePath(selectedFile.path)
   }

--- a/src/renderer/src/components/Home.tsx
+++ b/src/renderer/src/components/Home.tsx
@@ -12,7 +12,7 @@ function Home(): JSX.Element {
   }
   const handleClick = (): void => {
     const encodedFilePath = videoFilePath ? encodeURIComponent(videoFilePath) : null
-    navigate(`/sample?video=${encodedFilePath}`)
+    navigate(`/player?video=${encodedFilePath}`)
   }
 
   return (

--- a/src/renderer/src/components/Home.tsx
+++ b/src/renderer/src/components/Home.tsx
@@ -1,16 +1,29 @@
+import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 function Home(): JSX.Element {
   const navigate = useNavigate()
 
+  // WARN: 動画再生のテストのための処理であるため後で置き換える
+  const [videoFilePath, setVideoFilePath] = useState<string | null>(null)
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0]
+    if (selectedFile) setVideoFilePath(selectedFile.path)
+  }
   const handleClick = (): void => {
-    navigate('/sample')
+    const encodedFilePath = videoFilePath ? encodeURIComponent(videoFilePath) : null
+    navigate(`/sample?video=${encodedFilePath}`)
   }
 
   return (
     <div>
       <h1>ホーム画面</h1>
-      <button onClick={handleClick}>別の画面へ移動</button>
+      <div>
+        <h3>動画再生テスト用ファイルのアップロード</h3>
+        <h5>ここで選択したファイルが動画再生画面で再生されます</h5>
+        <input type="file" accept="video/mp4" onChange={handleFileChange} />
+      </div>
+      <button onClick={handleClick}>動画再生画面へ移動</button>
     </div>
   )
 }

--- a/src/renderer/src/components/Player.tsx
+++ b/src/renderer/src/components/Player.tsx
@@ -6,7 +6,7 @@ interface Comment {
   time: number
 }
 
-const Sample: React.FC = () => {
+const Player: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const [videoUrl, setVideoUrl] = useState<string | null>(null)
   const [comments, setComments] = useState<Comment[]>([])
@@ -87,4 +87,4 @@ const Sample: React.FC = () => {
   )
 }
 
-export default Sample
+export default Player

--- a/src/renderer/src/components/Sample.tsx
+++ b/src/renderer/src/components/Sample.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 
 interface Comment {
   text: string
@@ -7,8 +8,30 @@ interface Comment {
 
 const Sample: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null)
+  const [videoUrl, setVideoUrl] = useState<string | null>(null)
   const [comments, setComments] = useState<Comment[]>([])
   const [currentComment, setCurrentComment] = useState<string>('')
+
+  // クエリパラメータを取得
+  const query = new URLSearchParams(useLocation().search)
+  const videoFilePath = query.get('video') // 動画のファイルパス
+  // TODO: まだ使用しないキー入力のデータ
+  // const keysFilePath = query.get('keys')
+
+  // ページ読み込み時にクエリパラメータから動画をセットする
+  useEffect(() => {
+    if (!videoFilePath) return
+    window.fileSystem
+      .readFile(videoFilePath)
+      .then((data: Buffer) => {
+        const blob = new Blob([data], { type: 'video/mp4' })
+        const url = URL.createObjectURL(blob)
+        setVideoUrl(url)
+      })
+      .catch((err: Error) => {
+        console.error('ファイル読み込みエラー', err)
+      })
+  }, [])
 
   // コメントを追加
   const handleAddComment = (): void => {
@@ -30,8 +53,7 @@ const Sample: React.FC = () => {
       <div style={{ flex: 1 }}>
         <h1>Video</h1>
         <video ref={videoRef} width="600" controls>
-          <source src="path_to_your_video.mp4" type="video/mp4" />
-          Your browser does not support the video tag.
+          {videoUrl && <source src={videoUrl} type="video/mp4" />}
         </video>
       </div>
 

--- a/src/renderer/src/components/Sample.tsx
+++ b/src/renderer/src/components/Sample.tsx
@@ -14,7 +14,7 @@ const Sample: React.FC = () => {
 
   // クエリパラメータを取得
   const query = new URLSearchParams(useLocation().search)
-  const videoFilePath = query.get('video') // 動画のファイルパス
+  const videoFilePath = query.get('video') // FIXME: テスト用に用意した動画のパスを渡すためのパラメータ
   // TODO: まだ使用しないキー入力のデータ
   // const keysFilePath = query.get('keys')
 


### PR DESCRIPTION
## 概要

ローカルファイルを読み出して再生するような機能を追加した

動画指定の仮導線として`Home`に動画指定を行うための`<input>`を追加している

今はクエリとして`/player?video=<ファイルパス>`と渡されると次のページで動画が再生されるようになっているが、将来的には #4 で保存されたキーボードショートカットの記録をURLのクエリとして渡す想定